### PR TITLE
Resource provider test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
         "ext-imagick": "*",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "mockery/mockery": "^0.9.4"
     },
     "autoload": {
         "psr-4": { "Imanee\\": "src/" }

--- a/src/Imanee.php
+++ b/src/Imanee.php
@@ -55,7 +55,7 @@ class Imanee
         $this->drawer = new Drawer();
 
         if (!$resource) {
-            $provider = new ResourceProvider();
+            $provider = new ResourceProvider(new PhpExtensionAvailabilityChecker());
             $resource = $provider->createImageResource();
         }
 
@@ -589,7 +589,7 @@ class Imanee
 
         return $this;
     }
-    
+
     /**
      * Adds a frame for generating animated gifs with the animate() method
      * @param mixed $frame A string with a file path or an Imanee object

--- a/src/PhpExtensionAvailabilityChecker.php
+++ b/src/PhpExtensionAvailabilityChecker.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Imanee;
+
+/**
+ * Checks if an extension is loaded
+ */
+class PhpExtensionAvailabilityChecker
+{
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function isLoaded($name)
+    {
+        return extension_loaded($name);
+    }
+}

--- a/src/ResourceProvider.php
+++ b/src/ResourceProvider.php
@@ -38,10 +38,7 @@ class ResourceProvider
     /**
      * @return bool
      */
-    /**
-     * @return bool
-     */
-    public function imagickIsLoaded()
+    private function imagickIsLoaded()
     {
         return extension_loaded('imagick');
     }
@@ -49,7 +46,7 @@ class ResourceProvider
     /**
      * @return bool
      */
-    public function gdIsLoaded()
+    private function gdIsLoaded()
     {
         return extension_loaded('gd');
     }

--- a/src/ResourceProvider.php
+++ b/src/ResourceProvider.php
@@ -38,11 +38,6 @@ class ResourceProvider
     /**
      * @return bool
      */
-    public function imaneeIsSupported()
-    {
-        return ($this->imagickIsLoaded() or $this->gdIsLoaded());
-    }
-
     /**
      * @return bool
      */

--- a/src/ResourceProvider.php
+++ b/src/ResourceProvider.php
@@ -13,6 +13,19 @@ use Imanee\ImageResource\ImagickResource;
 class ResourceProvider
 {
     /**
+     * @var PhpExtensionAvailabilityChecker;
+     */
+    private $PhpExtensionAvailabilityChecker;
+
+    /**
+     * @param PhpExtensionAvailabilityChecker $PhpExtensionAvailabilityChecker
+     */
+    public function __construct(PhpExtensionAvailabilityChecker $PhpExtensionAvailabilityChecker)
+    {
+        $this->PhpExtensionAvailabilityChecker = $PhpExtensionAvailabilityChecker;
+    }
+
+    /**
      * Checks for loaded extensions to create a suitable ImageResource, in case neither Imagick or GD are loaded
      * throws an exception
      * @return GDResource|ImagickResource
@@ -40,7 +53,7 @@ class ResourceProvider
      */
     private function imagickIsLoaded()
     {
-        return extension_loaded('imagick');
+        return $this->PhpExtensionAvailabilityChecker->isLoaded('imagick');
     }
 
     /**
@@ -48,6 +61,6 @@ class ResourceProvider
      */
     private function gdIsLoaded()
     {
-        return extension_loaded('gd');
+        return $this->PhpExtensionAvailabilityChecker->isLoaded('gd');
     }
 }

--- a/tests/PhpExtensionAvailabilityCheckerTest.php
+++ b/tests/PhpExtensionAvailabilityCheckerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Imanee\Tests;
+
+use Imanee\PhpExtensionAvailabilityChecker;
+use PHPUnit_Framework_TestCase;
+
+class PhpExtensionAvailabilityCheckerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PhpExtensionAvailabilityChecker;
+     */
+    private $PhpExtensionAvailabilityChecker;
+
+    public function setUp()
+    {
+        $this->PhpExtensionAvailabilityChecker = new PhpExtensionAvailabilityChecker();
+    }
+
+    public function testShouldConfirmDefaultExtensionIsLoaded()
+    {
+        $this->assertTrue($this->PhpExtensionAvailabilityChecker->isLoaded('Core'));
+    }
+
+    public function testShouldConfirmUnknownExtensionIsNotLoaded()
+    {
+        $this->assertFalse($this->PhpExtensionAvailabilityChecker->isLoaded('foo-bar'));
+    }
+}

--- a/tests/ResourceProviderTest.php
+++ b/tests/ResourceProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Imanee\Tests;
+
+use Imanee\ResourceProvider;
+use PHPUnit_Framework_TestCase;
+use Mockery;
+
+class ResourceProviderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Mockery\MockInterface
+     */
+    private $PhpExtensionAvailabilityChecker;
+
+    /**
+     * @var ResourceProvider
+     */
+    private $resourceProvider;
+
+    public function setUp()
+    {
+        $this->PhpExtensionAvailabilityChecker = Mockery::mock('Imanee\PhpExtensionAvailabilityChecker');
+        $this->resourceProvider = new ResourceProvider($this->PhpExtensionAvailabilityChecker);
+    }
+
+    /**
+     * @expectedException Imanee\Exception\ExtensionNotFoundException
+     */
+    public function testFailIfNoUsableExtensionIsAvailable()
+    {
+        $this->PhpExtensionAvailabilityChecker
+            ->shouldReceive('isLoaded')
+            ->with('imagick')
+            ->andReturn(false);
+
+        $this->PhpExtensionAvailabilityChecker
+            ->shouldReceive('isLoaded')
+            ->with('gd')
+            ->andReturn(false);
+
+        $this->resourceProvider->createImageResource();
+    }
+
+    public function testShouldFailReturnGdResourceIfImagickIsNotAvailable()
+    {
+        $this->PhpExtensionAvailabilityChecker
+            ->shouldReceive('isLoaded')
+            ->with('imagick')
+            ->andReturn(false);
+        $this->PhpExtensionAvailabilityChecker
+            ->shouldReceive('isLoaded')
+            ->with('gd')
+            ->andReturn(true);
+
+        $this->assertInstanceOf('Imanee\ImageResource\GDResource', $this->resourceProvider->createImageResource());
+
+    }
+
+    public function testShouldReturnImagickResource()
+    {
+        $this->PhpExtensionAvailabilityChecker
+            ->shouldReceive('isLoaded')
+            ->with('imagick')
+            ->andReturn(true);
+
+        $this->assertInstanceOf('Imanee\ImageResource\ImagickResource', $this->resourceProvider->createImageResource());
+    }
+}

--- a/tests/ResourceProviderTest.php
+++ b/tests/ResourceProviderTest.php
@@ -27,7 +27,7 @@ class ResourceProviderTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException Imanee\Exception\ExtensionNotFoundException
      */
-    public function testFailIfNoUsableExtensionIsAvailable()
+    public function testshouldFailIfNoUsableExtensionIsAvailable()
     {
         $this->PhpExtensionAvailabilityChecker
             ->shouldReceive('isLoaded')


### PR DESCRIPTION
Fixes #36 

This PR adds tests both checking if an extension is available and creating an image resource, to achieve this these responsibilities had to be separated. Also Mockery was introduced to allow mocking the extension availability check