### PR TITLE
Imanee 33 unexpected results test

### DIFF
--- a/tests/ImageResource/GDResourceTest.php
+++ b/tests/ImageResource/GDResourceTest.php
@@ -40,7 +40,7 @@ class GDResourceTest extends \PHPUnit_Framework_TestCase
         $imageResource->load($file);
     }
     /**
-     * @covers \Imanee\ImageResource\GDResource::load
+     * @covers \Imanee\ImageResource\GDResource::loadColor
      * @group imanee-33
      * @dataProvider imageTypeProvider
      * @todo \Imanee\ImageResource\GDResource::load uses static method Imanee::getImageInfo


### PR DESCRIPTION
Detected some unexpected return values detected

```lang=php
1) Imanee\Tests\GDResourceTest::testLoadColourFailsWithBadInput with data set #0 ('AABBCCDD')
Imanee\Exception\InvalidColorException: Color 'AABBCCDD' is not supported use a HEX color or the name of a common color

/vagrant/imanee/src/ImageResource/GDPixel.php:65
/vagrant/imanee/src/ImageResource/GDPixel.php:41
/vagrant/imanee/src/ImageResource/GDResource.php:104
/vagrant/imanee/tests/ImageResource/GDResourceTest.php:80

2) Imanee\Tests\GDResourceTest::testLoadColourFailsWithBadInput with data set #1 ('foobar')
Imanee\Exception\InvalidColorException: Color 'foobar' is not supported use a HEX color or the name of a common color

/vagrant/imanee/src/ImageResource/GDPixel.php:65
/vagrant/imanee/src/ImageResource/GDPixel.php:41
/vagrant/imanee/src/ImageResource/GDResource.php:104
/vagrant/imanee/tests/ImageResource/GDResourceTest.php:80

3) Imanee\Tests\GDResourceTest::testLoadColourFailsWithBadInput with data set #2 ('#1234567')
Imanee\Exception\InvalidColorException: Color '1234567' is not supported use a HEX color or the name of a common color

/vagrant/imanee/src/ImageResource/GDPixel.php:65
/vagrant/imanee/src/ImageResource/GDPixel.php:41
/vagrant/imanee/src/ImageResource/GDResource.php:104
/vagrant/imanee/tests/ImageResource/GDResourceTest.php:80
```