### PR TITLE
Adding the tests for the output method of the GD ressource

### DIFF
--- a/src/ImageResource/GDResource.php
+++ b/src/ImageResource/GDResource.php
@@ -276,6 +276,7 @@ class GDResource extends Resource implements
     public function output($format = null)
     {
         $format = $format ?: $this->format;
+        ob_start();
         switch ($format) {
             case "jpg":
             case "jpeg":
@@ -292,10 +293,16 @@ class GDResource extends Resource implements
                 break;
 
             default:
+                ob_end_clean();
                 throw new UnsupportedFormatException(
                     sprintf("The format '%s' is not supported by this Resource.", $this->getMime())
                 );
         }
+
+        $image = ob_get_contents();
+        ob_end_clean();
+
+        return $image;
     }
 
     /**

--- a/tests/ImageResource/GDResourceTest.php
+++ b/tests/ImageResource/GDResourceTest.php
@@ -80,4 +80,45 @@ class GDResourceTest extends \PHPUnit_Framework_TestCase
         $gdResource->load($file);
         $this->assertFalse($gdResource->loadColor($color));
     }
+
+    /**
+     * @covers \Imanee\ImageResource\GDResource::output
+     * @dataProvider imageProvider
+     */
+    public function testReturnTheImageInsteadOfPuttingItInTheBuffer($imageRelativePath)
+    {
+        $file = __DIR__ . $imageRelativePath;
+        $gdResource = new GDResource();
+        $gdResource->load($file);
+
+        ob_start();
+        $image = $gdResource->output();
+        $buffer = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertNotEmpty($image);
+        $this->assertEmpty($buffer);
+    }
+
+    /**
+     * @covers \Imanee\ImageResource\GDResource::output
+     * @expectedException \Imanee\Exception\UnsupportedFormatException
+     */
+    public function testThrowErrorWhenFormatNotSupported()
+    {
+        $file = __DIR__ . '/_files/imanee.png';;
+        $gdResource = new GDResource();
+        $gdResource->load($file);
+
+        $gdResource->output('wrongFormat');
+    }
+
+    public function imageProvider()
+    {
+        return [
+            ['/_files/imanee.png'],
+            ['/_files/imanee.jpg'],
+            ['/_files/imanee.gif'],
+        ];
+    }
 }


### PR DESCRIPTION
Fixing the the output issue with GD.
GD would always put everything in the output buffer directly.