### PR TITLE
Fixes #63 - Add an option to not stretch images when they are smaller than the box

### DIFF
--- a/src/Imanee.php
+++ b/src/Imanee.php
@@ -167,12 +167,18 @@ class Imanee
      * @param bool $bestfit When set to true, will fit the image inside the provided box dimensions.
      *                      When set to false, will force resize to the specified dimensions, which
      *                      may cause the resulting image to be out of proportion.
+     * @param bool $stretch When set to false, an image smaller than the box area won't be scaled up
+     *                      to meet the desired size. Defaults to true
      *
      * @return $this
      */
-    public function resize($width, $height, $bestfit = true)
+    public function resize($width, $height, $bestfit = true, $stretch = true)
     {
-        $this->resource->resize($width, $height, $bestfit);
+        if (!$stretch and (($width >= $this->getWidth()) and ($height >= $this->getHeight()))) {
+            return $this;
+        }
+
+        $this->resource->resize($width, $height, $bestfit, $stretch);
 
         return $this;
     }

--- a/src/Imanee.php
+++ b/src/Imanee.php
@@ -222,15 +222,21 @@ class Imanee
      * fit thumbnail with the given dimensions, cropped by the center. If crop is false, the
      * thumbnail will use the best fit for the dimensions.
      *
-     * @param int  $width  Width of the thumbnail.
-     * @param int  $height Height of the thumbnail.
-     * @param bool $crop   When set to true, the thumbnail will be cropped from the center to match
-     *                     the given size.
+     * @param int  $width   Width of the thumbnail.
+     * @param int  $height  Height of the thumbnail.
+     * @param bool $crop    When set to true, the thumbnail will be cropped from the center to match
+     *                      the given size.
+     * @param bool $stretch When set to false, an image smaller than the box area won't be scaled up
+     *                      to meet the desired size. Defaults to true
      *
      * @return $this
      */
-    public function thumbnail($width, $height, $crop = false)
+    public function thumbnail($width, $height, $crop = false, $stretch = true)
     {
+        if (!$stretch and (($width >= $this->getWidth()) and ($height >= $this->getHeight()))) {
+            return $this;
+        }
+
         $this->resource->thumbnail($width, $height, $crop);
 
         return $this;

--- a/tests/ImaneeTest.php
+++ b/tests/ImaneeTest.php
@@ -97,6 +97,19 @@ class ImaneeTest extends \PHPUnit_Framework_TestCase
         $this->model->resize(200, 200);
     }
 
+    public function testShouldNotResizeWhenImageIsSmallerThanBoxAndStretchIsFalse()
+    {
+        $resource = $this->getMockBuilder('Imanee\ImageResource\GDResource')
+            ->setMethods(['resize'])
+            ->getMock();
+
+        $resource->expects($this->never())
+            ->method('resize');
+
+        $this->model->setResource($resource);
+        $this->model->resize(1200, 1200, true, false);
+    }
+
     public function testShouldRotate()
     {
         $resource = $this->getMockBuilder('Imanee\ImageResource\GDResource')
@@ -142,6 +155,20 @@ class ImaneeTest extends \PHPUnit_Framework_TestCase
         $this->model->setResource($resource);
         $this->model->thumbnail(200, 200);
         $this->model->thumbnail(200, 200, true);
+    }
+
+    public function testShouldNotThumbnailWhenImageIsSmallerThanBoxAndStretchIsFalse()
+    {
+        $resource = $this->getMockBuilder('Imanee\ImageResource\GDResource')
+            ->setMethods(['thumbnail'])
+            ->getMock();
+
+        $resource->expects($this->never())
+            ->method('thumbnail');
+
+
+        $this->model->setResource($resource);
+        $this->model->thumbnail(1200, 1200, false, false);
     }
 
     public function testSetAndGetResource()


### PR DESCRIPTION
This PR includes the option ``$stretch`` to the methods ``resize`` and ``thumbnail``.
The default behavior was not changed - when an image is smaller than the dimensions provided, by default it will be stretched to fit the desired size. When ``$stretch`` is set to false, the images smaller than the box size won't be touched.