### PR TITLE
fixed fail on write when extension is not availiable or uppercased

### DIFF
--- a/src/ImageResource/GDResource.php
+++ b/src/ImageResource/GDResource.php
@@ -366,8 +366,13 @@ class GDResource extends Resource implements
         // to lower down the extension (caused unknown extension for uppercased extension)
         if (isset($path['extension'])) {
             return strtolower($path['extension']);
-        } else {
+        } else if (is_string($this->getMime())) {
+            return str_replace("image/", "", $this->getMime());
+        } else if ($this->format != "") {
             return $this->format;
+        } else {
+            // fallback to enable save image on empty extension. ImageMagick has no problem with this.
+            return "jpg";
         }
     }
 

--- a/src/ImageResource/GDResource.php
+++ b/src/ImageResource/GDResource.php
@@ -362,7 +362,13 @@ class GDResource extends Resource implements
     {
         $path = pathinfo($filepath);
 
-        return $path['extension'];
+        // check if the file has the extenison and we need
+        // to lower down the extension (caused unknown extension for uppercased extension)
+        if (isset($path['extension'])) {
+            return strtolower($path['extension']);
+        } else {
+            return $this->format;
+        }
     }
 
     /**


### PR DESCRIPTION
When the filename has uppercase extension or it’s missing the exception is raised