### PR TITLE
Naming: ImageResource/Resource -> ImageResource/ImageResource (for PHP7)

### DIFF
--- a/src/ImageResource/GDResource.php
+++ b/src/ImageResource/GDResource.php
@@ -21,7 +21,7 @@ use Imanee\Model\ImageFilterableInterface;
 /**
  * GD-based image manipulator.
  */
-class GDResource extends Resource implements
+class GDResource extends ImageResource implements
     ImageResourceInterface,
     ImageComposableInterface,
     ImageWritableInterface,

--- a/src/ImageResource/ImageResource.php
+++ b/src/ImageResource/ImageResource.php
@@ -2,7 +2,7 @@
 
 namespace Imanee\ImageResource;
 
-abstract class Resource
+abstract class ImageResource
 {
     /**
      * Underlying resource.

--- a/src/ImageResource/ImagickResource.php
+++ b/src/ImageResource/ImagickResource.php
@@ -27,7 +27,7 @@ use Imanee\Model\ImageFilterableInterface;
 /**
  * Imagick-based image manipulator.
  */
-class ImagickResource extends Resource implements
+class ImagickResource extends ImageResource implements
     ImageResourceInterface,
     ImageWritableInterface,
     ImageComposableInterface,


### PR DESCRIPTION
Name "resource" is a reserved word for future use since PHP7. 

```
File: (...)/imanee/src/ImageResource/Resource.php
> Line 5: Name "resource" that is reserved for future use (does not cause an error in PHP 7) used as a class, interface or trait name
    abstract class Resource
    {
    }
```
